### PR TITLE
Improvements and fixes

### DIFF
--- a/Configuration/CacheSettings.cs
+++ b/Configuration/CacheSettings.cs
@@ -10,6 +10,8 @@ namespace IptvPlaylistAggregator.Configuration
 
         public int StreamDeadStatusCacheTimeout { get; set; }
 
+        public int StreamUnauthorisedStatusCacheTimeout { get; set; }
+
         public int StreamNotFoundStatusCacheTimeout { get; set; }
     }
 }

--- a/Configuration/CacheSettings.cs
+++ b/Configuration/CacheSettings.cs
@@ -3,5 +3,9 @@ namespace IptvPlaylistAggregator.Configuration
     public sealed class CacheSettings
     {
         public string CacheDirectoryPath { get; set; }
+
+        public int HostCacheTimeout { get; set; }
+
+        public int StreamStatusCacheTimeout { get; set; }
     }
 }

--- a/Configuration/CacheSettings.cs
+++ b/Configuration/CacheSettings.cs
@@ -9,5 +9,7 @@ namespace IptvPlaylistAggregator.Configuration
         public int StreamAliveStatusCacheTimeout { get; set; }
 
         public int StreamDeadStatusCacheTimeout { get; set; }
+
+        public int StreamNotFoundStatusCacheTimeout { get; set; }
     }
 }

--- a/Configuration/CacheSettings.cs
+++ b/Configuration/CacheSettings.cs
@@ -6,6 +6,8 @@ namespace IptvPlaylistAggregator.Configuration
 
         public int HostCacheTimeout { get; set; }
 
-        public int StreamStatusCacheTimeout { get; set; }
+        public int StreamAliveStatusCacheTimeout { get; set; }
+
+        public int StreamDeadStatusCacheTimeout { get; set; }
     }
 }

--- a/Data/channels.xml
+++ b/Data/channels.xml
@@ -2113,6 +2113,7 @@
     <GroupId>local-transilvania</GroupId>
     <LogoUrl>http://stvron.com/canale/mari/nova-tv-brasov.png</LogoUrl>
     <Aliases>
+      <string>RO: Nova Press</string>
       <string>RO: Nova TV Brasov</string>
     </Aliases>
   </ChannelDefinitionEntity>
@@ -2389,6 +2390,15 @@
     </Aliases>
   </ChannelDefinitionEntity>
   <ChannelDefinitionEntity>
+    <Id>QTV.ro</Id>
+    <Name>QTV</Name>
+    <GroupId>unknown</GroupId>
+    <LogoUrl></LogoUrl>
+    <Aliases>
+      <string>RO: QTV</string>
+    </Aliases>
+  </ChannelDefinitionEntity>
+  <ChannelDefinitionEntity>
     <Id>RadioCluj.ro</Id>
     <Name>Radio Cluj</Name>
     <GroupId>radio</GroupId>
@@ -2458,6 +2468,12 @@
     <Name>Retro TV</Name>
     <GroupId>music</GroupId>
     <LogoUrl>https://upload.wikimedia.org/wikipedia/commons/7/7b/Retro_Music_TV_logo.png</LogoUrl>
+  </ChannelDefinitionEntity>
+  <ChannelDefinitionEntity>
+    <Id>ROChannel.ro</Id>
+    <Name>RO Channel</Name>
+    <GroupId>international</GroupId>
+    <LogoUrl></LogoUrl>
   </ChannelDefinitionEntity>
   <ChannelDefinitionEntity>
     <Id>RockTV.ro</Id>
@@ -2641,9 +2657,13 @@
   </ChannelDefinitionEntity>
   <ChannelDefinitionEntity>
     <Id>TeleEuropaNova.ro</Id>
-    <Name>TeleEuropa Nova</Name>
+    <Name>Tele Nova</Name>
     <GroupId>local-banat</GroupId>
     <LogoUrl>https://raw.githubusercontent.com/hmlendea/tv-logos/master/logos/telenova.png</LogoUrl>
+    <Aliases>
+      <string>RO: Tele Nova Timișoara</string>
+      <string>RO: TeleEuropa Nova</string>
+    </Aliases>
   </ChannelDefinitionEntity>
   <ChannelDefinitionEntity>
     <Id>TelekomSport1.ro</Id>

--- a/Data/channels.xml
+++ b/Data/channels.xml
@@ -148,6 +148,7 @@
     <GroupId>local-dobrogea</GroupId>
     <LogoUrl>https://raw.githubusercontent.com/hmlendea/tv-logos/master/logos/alpha_media.png</LogoUrl>
     <Aliases>
+      <string>RO: Alfa Media TV</string>
       <string>RO: Alfa Media</string>
       <string>RO: Alpha Media TV</string>
       <string>RO: TV Alpha Media</string>
@@ -185,6 +186,7 @@
     <Aliases>
       <string>RO: Antena Comedy</string>
       <string>RO: Antena Play Comedy</string>
+      <string>RO: Antenna Comedy</string>
       <string>RO: Comedy Play</string>
     </Aliases>
   </ChannelDefinitionEntity>
@@ -2609,6 +2611,9 @@
     <Name>Super TV</Name>
     <GroupId>local-muntenia</GroupId>
     <LogoUrl>https://raw.githubusercontent.com/hmlendea/tv-logos/master/logos/super_tv.png</LogoUrl>
+    <Aliases>
+      <string>RO: Super TV Argeș</string>
+    </Aliases>
   </ChannelDefinitionEntity>
   <ChannelDefinitionEntity>
     <Id>SuperTennis.ro</Id>

--- a/Data/providers.xml
+++ b/Data/providers.xml
@@ -269,30 +269,6 @@
   </PlaylistProviderEntity>
   
   <PlaylistProviderEntity>
-    <Id>freeiptvdaily1</Id>
-    <IsEnabled>true</IsEnabled>
-    <Priority>520</Priority>
-    <Name>Free IPTV Daily 1</Name>
-    <UrlFormat>https://www.mediafire.com/file/s53fu5b8180r2hy/2-IPTV_Romania_M3u_Playlist.m3u/file</UrlFormat>
-  </PlaylistProviderEntity>
-
-  <PlaylistProviderEntity>
-    <Id>freeiptvdaily2</Id>
-    <IsEnabled>true</IsEnabled>
-    <Priority>521</Priority>
-    <Name>Free IPTV Daily 2</Name>
-    <UrlFormat>https://www.mediafire.com/file/5f3o1igg0iqdb3n/ROMANIA_IPTV2222.m3u/file</UrlFormat>
-  </PlaylistProviderEntity>
-
-  <PlaylistProviderEntity>
-    <Id>freeiptvdaily3</Id>
-    <IsEnabled>true</IsEnabled>
-    <Priority>522</Priority>
-    <Name>Free IPTV Daily 3</Name>
-    <UrlFormat>https://www.mediafire.com/file/jkihqazn2uouxeu/ro-m3uplaylist-1-1.m3u/file</UrlFormat>
-  </PlaylistProviderEntity>
-
-  <PlaylistProviderEntity>
     <Id>freeiptvplaylist</Id>
     <IsEnabled>true</IsEnabled>
     <Priority>530</Priority>
@@ -587,46 +563,6 @@
     <Name>Free Daily IPTV Link 6</Name>
     <UrlFormat>https://freedailyiptv.com/countries/RO/RO6_freedailyiptv.com.m3u</UrlFormat>
   </PlaylistProviderEntity>
-  
-  <PlaylistProviderEntity>
-    <Id>tousecurity1</Id>
-    <IsEnabled>true</IsEnabled>
-    <Priority>630</Priority>
-    <Name>Tousecurity List 1</Name>
-    <UrlFormat>https://sites.google.com/site/uup4mee/Romania%20M3u%20%281%29%20{0:dd-MM-yyyy}.m3u?attredirects=0&amp;d=1</UrlFormat>
-  </PlaylistProviderEntity>
-
-  <PlaylistProviderEntity>
-    <Id>tousecurity1-2</Id>
-    <IsEnabled>true</IsEnabled>
-    <Priority>631</Priority>
-    <Name>Tousecurity List 2</Name>
-    <UrlFormat>https://sites.google.com/site/uup4mee/Romania%20M3u%20%282%29%{0:dd-MM-yyyy}.m3u?attredirects=0&amp;d=1</UrlFormat>
-  </PlaylistProviderEntity>
-
-  <PlaylistProviderEntity>
-    <Id>tousecurity1-3</Id>
-    <IsEnabled>true</IsEnabled>
-    <Priority>632</Priority>
-    <Name>Tousecurity List 3</Name>
-    <UrlFormat>https://sites.google.com/site/uup4mee/Romania%20M3u%20%283%29%20{0:dd-MM-yyyy}.m3u?attredirects=0&amp;d=1</UrlFormat>
-  </PlaylistProviderEntity>
-
-  <PlaylistProviderEntity>
-    <Id>tousecurity2-1</Id>
-    <IsEnabled>true</IsEnabled>
-    <Priority>633</Priority>
-    <Name>Tousecurity Backup 1</Name>
-    <UrlFormat>https://sites.google.com/site/uup4mee/Romania%20%281%29%20{0:dd-MM-yyyy}m3u?attredirects=0&amp;d=1</UrlFormat>
-  </PlaylistProviderEntity>
-
-  <PlaylistProviderEntity>
-    <Id>tousecurity3-1</Id>
-    <IsEnabled>true</IsEnabled>
-    <Priority>634</Priority>
-    <Name>Tousecurity Uploadingy 1</Name>
-    <UrlFormat>https://sites.google.com/site/uploadingy/Romania%20M3u%20%282%29%20.m3u?attredirects=0&amp;d=1</UrlFormat>
-  </PlaylistProviderEntity>
 
   <PlaylistProviderEntity>
     <Id>albaiaiptv</Id>
@@ -691,5 +627,5 @@
     <Name>Valentin-gif's IPTV GitHub RO Channels</Name>
     <UrlFormat>https://raw.githubusercontent.com/Valentin-gif/silver-lamp/master/page1.txt</UrlFormat>
   </PlaylistProviderEntity>
-
+  
 </ArrayOfPlaylistProviderEntity>

--- a/Data/providers.xml
+++ b/Data/providers.xml
@@ -115,6 +115,14 @@
   </PlaylistProviderEntity>
 
   <PlaylistProviderEntity>
+    <Id>github-marokanul-ro</Id>
+    <IsEnabled>true</IsEnabled>
+    <Priority>160</Priority>
+    <Name>Marokanul's IPTV GitHub RO Channels</Name>
+    <UrlFormat>https://raw.githubusercontent.com/marokanul/iptv/master/iptv</UrlFormat>
+  </PlaylistProviderEntity>
+
+  <PlaylistProviderEntity>
     <Id>gitlab-cristy-ro</Id>
     <IsEnabled>true</IsEnabled>
     <Priority>170</Priority>
@@ -618,6 +626,14 @@
     <Priority>681</Priority>
     <Name>Free Tux TV Moldova</Name>
     <UrlFormat>http://database.freetuxtv.net/playlists/playlist_webtv_md.m3u</UrlFormat>
+  </PlaylistProviderEntity>
+
+  <PlaylistProviderEntity>
+    <Id>github-salex777-ro</Id>
+    <IsEnabled>true</IsEnabled>
+    <Priority>998</Priority>
+    <Name>Salex777-gif's IPTV GitHub RO Channels</Name>
+    <UrlFormat>https://raw.githubusercontent.com/salex777/iptvX/master/i.m3u</UrlFormat>
   </PlaylistProviderEntity>
 
   <PlaylistProviderEntity>

--- a/Data/providers.xml
+++ b/Data/providers.xml
@@ -115,14 +115,6 @@
   </PlaylistProviderEntity>
 
   <PlaylistProviderEntity>
-    <Id>github-marokanul-ro</Id>
-    <IsEnabled>true</IsEnabled>
-    <Priority>160</Priority>
-    <Name>Marokanul's IPTV GitHub RO Channels</Name>
-    <UrlFormat>https://raw.githubusercontent.com/marokanul/iptv/master/iptv</UrlFormat>
-  </PlaylistProviderEntity>
-
-  <PlaylistProviderEntity>
     <Id>gitlab-cristy-ro</Id>
     <IsEnabled>true</IsEnabled>
     <Priority>170</Priority>

--- a/Data/providers.xml
+++ b/Data/providers.xml
@@ -67,22 +67,6 @@
   </PlaylistProviderEntity>
 
   <PlaylistProviderEntity>
-    <Id>github-freearhey-ro</Id>
-    <IsEnabled>true</IsEnabled>
-    <Priority>114</Priority>
-    <Name>freearhey's IPTV GitHub RO Channels</Name>
-    <UrlFormat>https://raw.githubusercontent.com/freearhey/iptv/master/channels/ro.m3u</UrlFormat>
-  </PlaylistProviderEntity>
-
-  <PlaylistProviderEntity>
-    <Id>github-freearhey-md</Id>
-    <IsEnabled>true</IsEnabled>
-    <Priority>120</Priority>
-    <Name>freearhey's IPTV GitHub MD Channels</Name>
-    <UrlFormat>https://raw.githubusercontent.com/freearhey/iptv/master/channels/md.m3u</UrlFormat>
-  </PlaylistProviderEntity>
-
-  <PlaylistProviderEntity>
     <Id>github-makiptv-ro</Id>
     <IsEnabled>true</IsEnabled>
     <Priority>130</Priority>
@@ -134,8 +118,8 @@
     <Id>github-pabloangel</Id>
     <IsEnabled>true</IsEnabled>
     <Priority>180</Priority>
-    <Name>Pablo-Angel's IPTV GitHub Channels</Name>
-    <UrlFormat>https://raw.githubusercontent.com/Pablo-Angel/free/a5820225e5cd3e62de3389ebfde1ee07554e7e8b/gasca.m3u</UrlFormat>
+    <Name>Pablo-Angel's IPTV GitHub RO Channels</Name>
+    <UrlFormat>https://raw.githubusercontent.com/Pablo-Angel/StabilePablo.m3u/master/Romania.m3u</UrlFormat>
   </PlaylistProviderEntity>
 
   <PlaylistProviderEntity>
@@ -392,8 +376,40 @@
     <Id>iptvsource-backup3</Id>
     <IsEnabled>true</IsEnabled>
     <Priority>573</Priority>
-    <Name>IPTVsource Backup 4</Name>
+    <Name>IPTVsource Backup 3</Name>
     <UrlFormat>https://www.iptvsource.com/dl/ro_{0:ddMMyy}_iptvsource_com4.m3u</UrlFormat>
+  </PlaylistProviderEntity>
+
+  <PlaylistProviderEntity>
+    <Id>iptvsource-main-alt</Id>
+    <IsEnabled>true</IsEnabled>
+    <Priority>570</Priority>
+    <Name>IPTVsource (Alternative)</Name>
+    <UrlFormat>https://www.iptvsource.com/lists/ro_{0:ddMMyy}_iptvsource_com.m3u</UrlFormat>
+  </PlaylistProviderEntity>
+
+  <PlaylistProviderEntity>
+    <Id>iptvsource-backup1-alt</Id>
+    <IsEnabled>true</IsEnabled>
+    <Priority>571</Priority>
+    <Name>IPTVsource Backup 1 (Alternative)</Name>
+    <UrlFormat>https://www.iptvsource.com/lists/ro_{0:ddMMyy}_iptvsource_com2.m3u</UrlFormat>
+  </PlaylistProviderEntity>
+
+  <PlaylistProviderEntity>
+    <Id>iptvsource-backup2-alt</Id>
+    <IsEnabled>true</IsEnabled>
+    <Priority>572</Priority>
+    <Name>IPTVsource Backup 2 (Alternative)</Name>
+    <UrlFormat>https://www.iptvsource.com/lists/ro_{0:ddMMyy}_iptvsource_com3.m3u</UrlFormat>
+  </PlaylistProviderEntity>
+
+  <PlaylistProviderEntity>
+    <Id>iptvsource-backup3-alt</Id>
+    <IsEnabled>true</IsEnabled>
+    <Priority>573</Priority>
+    <Name>IPTVsource Backup 3 (Alternative)</Name>
+    <UrlFormat>https://www.iptvsource.com/lists/ro_{0:ddMMyy}_iptvsource_com4.m3u</UrlFormat>
   </PlaylistProviderEntity>
 
   <PlaylistProviderEntity>
@@ -463,7 +479,7 @@
   <PlaylistProviderEntity>
     <Id>gatachannel-link1</Id>
     <IsEnabled>true</IsEnabled>
-    <Priority>601</Priority>
+    <Priority>610</Priority>
     <Name>gatachannel Link 1</Name>
     <UrlFormat>https://gatachannel.com/iptv/Romanian-{0:dd-MM-yy}.m3u</UrlFormat>
   </PlaylistProviderEntity>
@@ -471,7 +487,7 @@
   <PlaylistProviderEntity>
     <Id>gatachannel-link2</Id>
     <IsEnabled>true</IsEnabled>
-    <Priority>602</Priority>
+    <Priority>611</Priority>
     <Name>gatachannel Link 2</Name>
     <UrlFormat>http://gatachannel.com/iptv/worldwide/iptv-romania/ro-{0:dd-MM-yyyy}.m3u</UrlFormat>
   </PlaylistProviderEntity>
@@ -479,7 +495,7 @@
   <PlaylistProviderEntity>
     <Id>freeiptvserver</Id>
     <IsEnabled>true</IsEnabled>
-    <Priority>610</Priority>
+    <Priority>620</Priority>
     <Name>Free IPTV Server</Name>
     <UrlFormat>https://freeiptvserver.com/dl/ro_{0:ddMMyy}_iptvsource_com.m3u</UrlFormat>
   </PlaylistProviderEntity>
@@ -487,7 +503,7 @@
   <PlaylistProviderEntity>
     <Id>freeiptvserver-backup1</Id>
     <IsEnabled>true</IsEnabled>
-    <Priority>611</Priority>
+    <Priority>621</Priority>
     <Name>Free IPTV Server Backup 1</Name>
     <UrlFormat>https://freeiptvserver.com/dl/ro_{0:ddMMyy}_iptvsource_com2.m3u</UrlFormat>
   </PlaylistProviderEntity>
@@ -495,7 +511,7 @@
   <PlaylistProviderEntity>
     <Id>freeiptvserver-backup2</Id>
     <IsEnabled>true</IsEnabled>
-    <Priority>612</Priority>
+    <Priority>623</Priority>
     <Name>Free IPTV Server Backup 2</Name>
     <UrlFormat>https://freeiptvserver.com/dl/ro_{0:ddMMyy}_iptvsource_com3.m3u</UrlFormat>
   </PlaylistProviderEntity>
@@ -503,7 +519,7 @@
   <PlaylistProviderEntity>
     <Id>freeiptvserver-backup3</Id>
     <IsEnabled>true</IsEnabled>
-    <Priority>613</Priority>
+    <Priority>624</Priority>
     <Name>Free IPTV Server Backup 3</Name>
     <UrlFormat>https://freeiptvserver.com/dl/ro_{0:ddMMyy}_iptvsource_com4.m3u</UrlFormat>
   </PlaylistProviderEntity>
@@ -511,7 +527,7 @@
   <PlaylistProviderEntity>
     <Id>freeiptvserver-backup4</Id>
     <IsEnabled>true</IsEnabled>
-    <Priority>614</Priority>
+    <Priority>625</Priority>
     <Name>Free IPTV Server Backup 4</Name>
     <UrlFormat>https://freeiptvserver.com/dl/ro_{0:ddMMyy}_iptvsource_com5.m3u</UrlFormat>
   </PlaylistProviderEntity>
@@ -519,7 +535,7 @@
   <PlaylistProviderEntity>
     <Id>freedailyiptv-link1</Id>
     <IsEnabled>true</IsEnabled>
-    <Priority>620</Priority>
+    <Priority>230</Priority>
     <Name>Free Daily IPTV Link 1</Name>
     <UrlFormat>https://freedailyiptv.com/countries/RO/RO_freedailyiptv.com.m3u</UrlFormat>
   </PlaylistProviderEntity>
@@ -527,7 +543,7 @@
   <PlaylistProviderEntity>
     <Id>freedailyiptv-link2</Id>
     <IsEnabled>true</IsEnabled>
-    <Priority>621</Priority>
+    <Priority>631</Priority>
     <Name>Free Daily IPTV 2</Name>
     <UrlFormat>https://freedailyiptv.com/countries/RO/RO2_freedailyiptv.com.m3u</UrlFormat>
   </PlaylistProviderEntity>
@@ -535,7 +551,7 @@
   <PlaylistProviderEntity>
     <Id>freedailyiptv-link3</Id>
     <IsEnabled>true</IsEnabled>
-    <Priority>623</Priority>
+    <Priority>632</Priority>
     <Name>Free Daily IPTV Link 3</Name>
     <UrlFormat>https://freedailyiptv.com/countries/RO/RO3_freedailyiptv.com.m3u</UrlFormat>
   </PlaylistProviderEntity>
@@ -543,7 +559,7 @@
   <PlaylistProviderEntity>
     <Id>freedailyiptv-link4</Id>
     <IsEnabled>true</IsEnabled>
-    <Priority>624</Priority>
+    <Priority>633</Priority>
     <Name>Free Daily IPTV Link 4</Name>
     <UrlFormat>https://freedailyiptv.com/countries/RO/RO4_freedailyiptv.com.m3u</UrlFormat>
   </PlaylistProviderEntity>
@@ -551,7 +567,7 @@
   <PlaylistProviderEntity>
     <Id>freedailyiptv-link5</Id>
     <IsEnabled>true</IsEnabled>
-    <Priority>625</Priority>
+    <Priority>634</Priority>
     <Name>Free Daily IPTV Link 5</Name>
     <UrlFormat>https://freedailyiptv.com/countries/RO/RO5_freedailyiptv.com.m3u</UrlFormat>
   </PlaylistProviderEntity>
@@ -559,7 +575,7 @@
   <PlaylistProviderEntity>
     <Id>freedailyiptv-link6</Id>
     <IsEnabled>true</IsEnabled>
-    <Priority>626</Priority>
+    <Priority>635</Priority>
     <Name>Free Daily IPTV Link 6</Name>
     <UrlFormat>https://freedailyiptv.com/countries/RO/RO6_freedailyiptv.com.m3u</UrlFormat>
   </PlaylistProviderEntity>
@@ -618,6 +634,38 @@
     <Priority>681</Priority>
     <Name>Free Tux TV Moldova</Name>
     <UrlFormat>http://database.freetuxtv.net/playlists/playlist_webtv_md.m3u</UrlFormat>
+  </PlaylistProviderEntity>
+
+  <PlaylistProviderEntity>
+    <Id>source-iptv-ro-main</Id>
+    <IsEnabled>true</IsEnabled>
+    <Priority>690</Priority>
+    <Name>Source-IPTV Romania</Name>
+    <UrlFormat>http://www.source-iptv.com/files/ro_{0:ddMMyy}_source-iptv_com.m3u</UrlFormat>
+  </PlaylistProviderEntity>
+
+  <PlaylistProviderEntity>
+    <Id>source-iptv-ro-backup1</Id>
+    <IsEnabled>true</IsEnabled>
+    <Priority>691</Priority>
+    <Name>Source-IPTV Romania Backup 1</Name>
+    <UrlFormat>http://www.source-iptv.com/files/ro_{0:ddMMyy}_source-iptv_com2.m3u</UrlFormat>
+  </PlaylistProviderEntity>
+
+  <PlaylistProviderEntity>
+    <Id>source-iptv-ro-backup2</Id>
+    <IsEnabled>true</IsEnabled>
+    <Priority>692</Priority>
+    <Name>Source-IPTV Romania Backup 2</Name>
+    <UrlFormat>http://www.source-iptv.com/files/ro_{0:ddMMyy}_source-iptv_com3.m3u</UrlFormat>
+  </PlaylistProviderEntity>
+
+  <PlaylistProviderEntity>
+    <Id>source-iptv-ro-backup3</Id>
+    <IsEnabled>true</IsEnabled>
+    <Priority>693</Priority>
+    <Name>Source-IPTV Romania Backup 3</Name>
+    <UrlFormat>http://www.source-iptv.com/files/ro_{0:ddMMyy}_source-iptv_com4.m3u</UrlFormat>
   </PlaylistProviderEntity>
 
   <PlaylistProviderEntity>

--- a/Logging/MyLogInfoKey.cs
+++ b/Logging/MyLogInfoKey.cs
@@ -17,5 +17,7 @@ namespace IptvPlaylistAggregator.Logging
         public static LogInfoKey Group => new MyLogInfoKey(nameof(Group));
 
         public static LogInfoKey Provider => new MyLogInfoKey(nameof(Provider));
+
+        public static LogInfoKey Url => new MyLogInfoKey(nameof(Url));
     }
 }

--- a/Logging/MyLogInfoKey.cs
+++ b/Logging/MyLogInfoKey.cs
@@ -19,5 +19,7 @@ namespace IptvPlaylistAggregator.Logging
         public static LogInfoKey Provider => new MyLogInfoKey(nameof(Provider));
 
         public static LogInfoKey Url => new MyLogInfoKey(nameof(Url));
+
+        public static LogInfoKey StreamState => new MyLogInfoKey(nameof(StreamState));
     }
 }

--- a/Logging/MyOperation.cs
+++ b/Logging/MyOperation.cs
@@ -15,5 +15,9 @@ namespace IptvPlaylistAggregator.Logging
         public static Operation ProviderChannelsFiltering => new MyOperation(nameof(ProviderChannelsFiltering));
 
         public static Operation ChannelMatching => new MyOperation(nameof(ChannelMatching));
+
+        public static Operation MediaSourceCheck => new MyOperation(nameof(CacheSaving));
+
+        public static Operation CacheSaving => new MyOperation(nameof(CacheSaving));
     }
 }

--- a/Logging/MyOperation.cs
+++ b/Logging/MyOperation.cs
@@ -16,7 +16,7 @@ namespace IptvPlaylistAggregator.Logging
 
         public static Operation ChannelMatching => new MyOperation(nameof(ChannelMatching));
 
-        public static Operation MediaSourceCheck => new MyOperation(nameof(CacheSaving));
+        public static Operation MediaSourceCheck => new MyOperation(nameof(MediaSourceCheck));
 
         public static Operation CacheSaving => new MyOperation(nameof(CacheSaving));
     }

--- a/Program.cs
+++ b/Program.cs
@@ -28,9 +28,6 @@ namespace IptvPlaylistAggregator
 
         public static void Main(string[] args)
         {
-            Environment.SetEnvironmentVariable("LD_PRELOAD", "/usr/lib/libcurl.so.3");
-            Environment.SetEnvironmentVariable("DOTNET_SYSTEM_NET_HTTP_USESOCKETSHTTPHANDLER", "0");
-
             IConfiguration config = LoadConfiguration();
 
             applicationSettings = new ApplicationSettings();

--- a/Program.cs
+++ b/Program.cs
@@ -11,6 +11,7 @@ using NuciLog.Core;
 
 using IptvPlaylistAggregator.Configuration;
 using IptvPlaylistAggregator.DataAccess.DataObjects;
+using IptvPlaylistAggregator.Logging;
 using IptvPlaylistAggregator.Service;
 
 namespace IptvPlaylistAggregator
@@ -21,6 +22,9 @@ namespace IptvPlaylistAggregator
         static CacheSettings cacheSettings;
         static DataStoreSettings dataStoreSettings;
         static NuciLoggerSettings nuciLoggerSettings;
+
+        static ILogger logger;
+        static ICacheManager cacheManager;
 
         public static void Main(string[] args)
         {
@@ -58,7 +62,9 @@ namespace IptvPlaylistAggregator
                 .AddSingleton<ILogger, NuciLogger>()
                 .BuildServiceProvider();
             
-            ILogger logger = serviceProvider.GetService<ILogger>();
+            logger = serviceProvider.GetService<ILogger>();
+            cacheManager = serviceProvider.GetService<ICacheManager>();
+
             logger.Info(Operation.StartUp, OperationStatus.Success);
 
             try
@@ -80,6 +86,8 @@ namespace IptvPlaylistAggregator
                 logger.Fatal(Operation.Unknown, OperationStatus.Failure, ex);
             }
 
+            SaveCacheToDisk();
+
             logger.Info(Operation.ShutDown, OperationStatus.Success);
         }
         
@@ -88,6 +96,13 @@ namespace IptvPlaylistAggregator
             return new ConfigurationBuilder()
                 .AddJsonFile("appsettings.json", true, true)
                 .Build();
+        }
+
+        static void SaveCacheToDisk()
+        {
+            logger.Info(MyOperation.CacheSaving, OperationStatus.Started);
+            cacheManager.SaveCacheToDisk();
+            logger.Debug(MyOperation.CacheSaving, OperationStatus.Success);
         }
     }
 }

--- a/Program.cs
+++ b/Program.cs
@@ -73,10 +73,7 @@ namespace IptvPlaylistAggregator
             }
             catch (AggregateException ex)
             {
-                foreach (Exception innerException in ex.InnerExceptions)
-                {
-                    logger.Fatal(Operation.Unknown, OperationStatus.Failure, innerException);
-                }
+                LogInnerExceptions(ex);
             }
             catch (Exception ex)
             {
@@ -93,6 +90,23 @@ namespace IptvPlaylistAggregator
             return new ConfigurationBuilder()
                 .AddJsonFile("appsettings.json", true, true)
                 .Build();
+        }
+
+        static void LogInnerExceptions(AggregateException exception)
+        {
+            foreach (Exception innerException in exception.InnerExceptions)
+            {
+                AggregateException innerAggregateException = innerException as AggregateException;
+
+                if (innerAggregateException is null)
+                {
+                    logger.Fatal(Operation.Unknown, OperationStatus.Failure, innerException);
+                }
+                else
+                {
+                    LogInnerExceptions(innerException as AggregateException);
+                }
+            }
         }
 
         static void SaveCacheToDisk()

--- a/Service/CacheManager.cs
+++ b/Service/CacheManager.cs
@@ -1,6 +1,10 @@
 using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
+using System.Linq;
+using System.Security.Cryptography.X509Certificates;
 
 using NuciExtensions;
 
@@ -11,13 +15,18 @@ namespace IptvPlaylistAggregator.Service
 {
     public sealed class CacheManager : ICacheManager
     {
-        const string PlaylistFileNameFOrmat = "{0}_playlist_{1:yyyy-MM-dd}.m3u";
+        const char CsvFieldSeparator = ',';
+        const string TimestampFormat = "yyyy-MM-dd_HH-mm-ss";
+        const string PlaylistFileNameFormat = "{0}_playlist_{1:yyyy-MM-dd}.m3u";
+        const string HostsFileName = "hosts.csv";
+        const string StreamStatusesFileName = "stream-statuses.csv";
 
         readonly CacheSettings cacheSettings;
 
         readonly ConcurrentDictionary<string, string> normalisedNames;
-        readonly ConcurrentDictionary<string, string> hostnameResolutions;
+        readonly ConcurrentDictionary<string, Host> hosts;
         readonly ConcurrentDictionary<string, string> urlResolutions;
+        readonly ConcurrentDictionary<string, X509Certificate2> sslCertificates;
         readonly ConcurrentDictionary<string, MediaStreamStatus> streamStatuses;
         readonly ConcurrentDictionary<string, string> webDownloads;
         readonly ConcurrentDictionary<int, Playlist> playlists;
@@ -27,13 +36,25 @@ namespace IptvPlaylistAggregator.Service
             this.cacheSettings = cacheSettings;
 
             normalisedNames = new ConcurrentDictionary<string, string>();
-            hostnameResolutions = new ConcurrentDictionary<string, string>();
+            hosts = new ConcurrentDictionary<string, Host>();
             urlResolutions = new ConcurrentDictionary<string, string>();
+            sslCertificates = new ConcurrentDictionary<string, X509Certificate2>();
             streamStatuses = new ConcurrentDictionary<string, MediaStreamStatus>();
             webDownloads = new ConcurrentDictionary<string, string>();
             playlists = new ConcurrentDictionary<int, Playlist>();
 
             PrepareFilesystem();
+
+            LoadHosts();
+            LoadStreamStatuses();
+
+            Console.WriteLine(streamStatuses.Count);
+        }
+
+        public void SaveCacheToDisk()
+        {
+            SaveHosts();
+            SaveStreamStatuses();
         }
 
         public void StoreNormalisedChannelName(string name, string normalisedName)
@@ -42,18 +63,13 @@ namespace IptvPlaylistAggregator.Service
         public string GetNormalisedChannelName(string name)
             => normalisedNames.TryGetValue(name);
 
-        public void StoreHostnameResolution(string hostname, string ip)
+        public void StoreHost(Host host)
         {
-            if (ip is null)
-            {
-                ip = string.Empty;
-            }
-            
-            hostnameResolutions.TryAdd(hostname, ip);
+            hosts.TryAdd(host.Domain, host);
         }
 
-        public string GetHostnameResolution(string hostname)
-            => hostnameResolutions.TryGetValue(hostname);
+        public Host GetHost(string domain)
+            => hosts.TryGetValue(domain);
 
         public void StoreUrlResolution(string url, string ip)
         {
@@ -75,26 +91,41 @@ namespace IptvPlaylistAggregator.Service
             return urlResolutions.TryGetValue(url);
         }
 
-        public void StoreStreamStatus(MediaStreamStatus status)
-            => streamStatuses.TryAdd(status.Url, status);
-
-        public MediaStreamStatus GetStreamStatus(string url)
+        public void StoreSslCertificate(string host, X509Certificate2 certificate)
         {
-            MediaStreamStatus cachedStatus = streamStatuses.TryGetValue(url);
-
-            if (!(cachedStatus is null))
+            if (!string.IsNullOrWhiteSpace(host) && !(certificate is null))
             {
-                return cachedStatus;
+                sslCertificates.TryAdd(host, certificate);
             }
-            
-            string resolvedUrl = urlResolutions.TryGetValue(url);
-            
-            if (resolvedUrl is null)
+        }
+
+        public X509Certificate2 GetSslCertificate(string host)
+        {
+            if (string.IsNullOrWhiteSpace(host))
             {
                 return null;
             }
+            
+            return sslCertificates.TryGetValue(host);
+        }
 
-            return streamStatuses.TryGetValue(resolvedUrl);
+        public void StoreStreamStatus(MediaStreamStatus streamStatus)
+        {
+            streamStatuses.TryAdd(streamStatus.Url, streamStatus);
+        }
+
+        public MediaStreamStatus GetStreamStatus(string url)
+        {
+            MediaStreamStatus streamStatus = streamStatuses.TryGetValue(url);
+            
+            string resolvedUrl = urlResolutions.TryGetValue(url);
+            
+            if (streamStatus is null && !(resolvedUrl is null) && resolvedUrl != url)
+            {
+                streamStatus = streamStatuses.TryGetValue(resolvedUrl);
+            }
+
+            return streamStatus;
         }
         
         public void StoreWebDownload(string url, string content)
@@ -127,7 +158,7 @@ namespace IptvPlaylistAggregator.Service
 
         public void StorePlaylistFile(string providerId, DateTime date, string content)
         {
-            string fileName = string.Format(PlaylistFileNameFOrmat, providerId, date);
+            string fileName = string.Format(PlaylistFileNameFormat, providerId, date);
             string filePath = Path.Combine(cacheSettings.CacheDirectoryPath, fileName);
 
             File.WriteAllText(filePath, content);
@@ -135,7 +166,7 @@ namespace IptvPlaylistAggregator.Service
 
         public string GetPlaylistFile(string providerId, DateTime date)
         {
-            string fileName = string.Format(PlaylistFileNameFOrmat, providerId, date);
+            string fileName = string.Format(PlaylistFileNameFormat, providerId, date);
             string filePath = Path.Combine(cacheSettings.CacheDirectoryPath, fileName);
             
             if (File.Exists(filePath))
@@ -152,6 +183,99 @@ namespace IptvPlaylistAggregator.Service
             {
                 Directory.CreateDirectory(cacheSettings.CacheDirectoryPath);
             }
+        }
+
+        void LoadHosts()
+        {
+            string filePath = Path.Combine(cacheSettings.CacheDirectoryPath, HostsFileName);
+
+            if (!File.Exists(filePath))
+            {
+                return;
+            }
+
+            List<string> lines = File.ReadAllLines(filePath).ToList();
+
+            foreach (string line in lines)
+            {
+                string[] fields = line.Split(CsvFieldSeparator);
+
+                Host host = new Host();
+                host.Domain = fields[0];
+                host.Ip = fields[1];
+                host.ResolutionTime = DateTime.ParseExact(fields[2], TimestampFormat, CultureInfo.InvariantCulture);
+
+                if ((DateTime.UtcNow - host.ResolutionTime).TotalSeconds <= cacheSettings.HostCacheTimeout)
+                {
+                    hosts.TryAdd(host.Domain, host);
+                }
+            }
+        }
+
+        void LoadStreamStatuses()
+        {
+            string filePath = Path.Combine(cacheSettings.CacheDirectoryPath, StreamStatusesFileName);
+
+            if (!File.Exists(filePath))
+            {
+                return;
+            }
+
+            List<string> lines = File.ReadAllLines(filePath).ToList();
+
+            foreach (string line in lines)
+            {
+                string[] fields = line.Split(CsvFieldSeparator);
+
+                MediaStreamStatus streamStatus = new MediaStreamStatus();
+                streamStatus.Url = fields[0];
+                streamStatus.LastCheckTime = DateTime.ParseExact(fields[1], TimestampFormat, CultureInfo.InvariantCulture);
+                streamStatus.IsAlive = bool.Parse(fields[2]);
+
+                if ((DateTime.UtcNow - streamStatus.LastCheckTime).TotalSeconds <= cacheSettings.StreamStatusCacheTimeout)
+                {
+                    streamStatuses.TryAdd(streamStatus.Url, streamStatus);
+                }
+            }
+        }
+
+        void SaveHosts()
+        {
+            string filePath = Path.Combine(cacheSettings.CacheDirectoryPath, HostsFileName);
+
+            List<string> lines = new List<string>();
+
+            foreach (Host host in hosts.Values
+                .OrderBy(x => x.Domain)
+                .ThenBy(x => x.Ip)
+                .ThenBy(x => x.ResolutionTime))
+            {
+                string timestamp = host.ResolutionTime.ToString(
+                    TimestampFormat,
+                    CultureInfo.InvariantCulture);
+
+                lines.Add($"{host.Domain}{CsvFieldSeparator}{host.Ip}{CsvFieldSeparator}{timestamp}");
+            }
+
+            File.WriteAllLines(filePath, lines);
+        }
+
+        void SaveStreamStatuses()
+        {
+            string filePath = Path.Combine(cacheSettings.CacheDirectoryPath, StreamStatusesFileName);
+
+            List<string> lines = new List<string>();
+
+            foreach (MediaStreamStatus streamStatus in streamStatuses.Values)
+            {
+                string timestamp = streamStatus.LastCheckTime.ToString(
+                    TimestampFormat,
+                    CultureInfo.InvariantCulture);
+
+                lines.Add($"{streamStatus.Url}{CsvFieldSeparator}{timestamp}{CsvFieldSeparator}{streamStatus.IsAlive}");
+            }
+
+            File.WriteAllLines(filePath, lines);
         }
     }
 }

--- a/Service/CacheManager.cs
+++ b/Service/CacheManager.cs
@@ -228,10 +228,11 @@ namespace IptvPlaylistAggregator.Service
                 MediaStreamStatus streamStatus = new MediaStreamStatus();
                 streamStatus.Url = fields[0];
                 streamStatus.LastCheckTime = DateTime.ParseExact(fields[1], TimestampFormat, CultureInfo.InvariantCulture);
-                streamStatus.IsAlive = bool.Parse(fields[2]);
+                streamStatus.State = (StreamState)Enum.Parse(typeof(StreamState), fields[2]);
 
-                if ((streamStatus.IsAlive == true && (DateTime.UtcNow - streamStatus.LastCheckTime).TotalSeconds > cacheSettings.StreamAliveStatusCacheTimeout) ||
-                    (streamStatus.IsAlive == false && (DateTime.UtcNow - streamStatus.LastCheckTime).TotalSeconds > cacheSettings.StreamDeadStatusCacheTimeout))
+                if ((streamStatus.State == StreamState.Alive && (DateTime.UtcNow - streamStatus.LastCheckTime).TotalSeconds > cacheSettings.StreamAliveStatusCacheTimeout) ||
+                    (streamStatus.State == StreamState.Dead && (DateTime.UtcNow - streamStatus.LastCheckTime).TotalSeconds > cacheSettings.StreamDeadStatusCacheTimeout) ||
+                    (streamStatus.State == StreamState.NotFound && (DateTime.UtcNow - streamStatus.LastCheckTime).TotalSeconds > cacheSettings.StreamNotFoundStatusCacheTimeout))
                 {
                     continue;
                 }

--- a/Service/CacheManager.cs
+++ b/Service/CacheManager.cs
@@ -83,7 +83,7 @@ namespace IptvPlaylistAggregator.Service
         {
             if (string.IsNullOrWhiteSpace(url))
             {
-                return null;
+                return string.Empty;
             }
             
             return urlResolutions.TryGetValue(url);
@@ -118,7 +118,7 @@ namespace IptvPlaylistAggregator.Service
             
             string resolvedUrl = urlResolutions.TryGetValue(url);
 
-            if (string.IsNullOrWhiteSpace(resolvedUrl))
+            if (resolvedUrl == string.Empty)
             {
                 return new MediaStreamStatus()
                 {
@@ -127,10 +127,12 @@ namespace IptvPlaylistAggregator.Service
                     LastCheckTime = DateTime.UtcNow
                 };
             }
-            
-            if (streamStatus is null && resolvedUrl != url)
+            else if (!(resolvedUrl is null))
             {
-                streamStatus = streamStatuses.TryGetValue(resolvedUrl);
+                if (streamStatus is null && resolvedUrl != url)
+                {
+                    streamStatus = streamStatuses.TryGetValue(resolvedUrl);
+                }
             }
 
             return streamStatus;
@@ -150,16 +152,18 @@ namespace IptvPlaylistAggregator.Service
             
             string resolvedUrl = urlResolutions.TryGetValue(url);
             
-            if (resolvedUrl is null)
+            if (resolvedUrl == string.Empty)
             {
                 return string.Empty;
             }
-
-            cachedDownload = webDownloads.TryGetValue(resolvedUrl);
-
-            if (!(cachedDownload is null))
+            else if (!(resolvedUrl is null))
             {
-                return cachedDownload;
+                cachedDownload = webDownloads.TryGetValue(resolvedUrl);
+
+                if (!(cachedDownload is null))
+                {
+                    return cachedDownload;
+                }
             }
 
             MediaStreamStatus streamStatus = GetStreamStatus(url);

--- a/Service/CacheManager.cs
+++ b/Service/CacheManager.cs
@@ -232,6 +232,7 @@ namespace IptvPlaylistAggregator.Service
 
                 if ((streamStatus.State == StreamState.Alive && (DateTime.UtcNow - streamStatus.LastCheckTime).TotalSeconds > cacheSettings.StreamAliveStatusCacheTimeout) ||
                     (streamStatus.State == StreamState.Dead && (DateTime.UtcNow - streamStatus.LastCheckTime).TotalSeconds > cacheSettings.StreamDeadStatusCacheTimeout) ||
+                    (streamStatus.State == StreamState.Unauthorised && (DateTime.UtcNow - streamStatus.LastCheckTime).TotalSeconds > cacheSettings.StreamUnauthorisedStatusCacheTimeout) ||
                     (streamStatus.State == StreamState.NotFound && (DateTime.UtcNow - streamStatus.LastCheckTime).TotalSeconds > cacheSettings.StreamNotFoundStatusCacheTimeout))
                 {
                     continue;
@@ -274,7 +275,7 @@ namespace IptvPlaylistAggregator.Service
                     TimestampFormat,
                     CultureInfo.InvariantCulture);
 
-                lines.Add($"{streamStatus.Url}{CsvFieldSeparator}{timestamp}{CsvFieldSeparator}{streamStatus.IsAlive}");
+                lines.Add($"{streamStatus.Url}{CsvFieldSeparator}{timestamp}{CsvFieldSeparator}{streamStatus.State}");
             }
 
             File.WriteAllLines(filePath, lines);

--- a/Service/CacheManager.cs
+++ b/Service/CacheManager.cs
@@ -302,8 +302,15 @@ namespace IptvPlaylistAggregator.Service
                 string timestamp = streamStatus.LastCheckTime.ToString(
                     TimestampFormat,
                     CultureInfo.InvariantCulture);
+                
+                string url = streamStatus.Url;
 
-                lines.Add($"{streamStatus.Url}{CsvFieldSeparator}{timestamp}{CsvFieldSeparator}{streamStatus.State}");
+                if (url.Contains(','))
+                {
+                    url = url.Split(',')[0];
+                }
+
+                lines.Add($"{url}{CsvFieldSeparator}{timestamp}{CsvFieldSeparator}{streamStatus.State}");
             }
 
             File.WriteAllLines(filePath, lines);

--- a/Service/CacheManager.cs
+++ b/Service/CacheManager.cs
@@ -47,8 +47,6 @@ namespace IptvPlaylistAggregator.Service
 
             LoadHosts();
             LoadStreamStatuses();
-
-            Console.WriteLine(streamStatuses.Count);
         }
 
         public void SaveCacheToDisk()
@@ -232,10 +230,13 @@ namespace IptvPlaylistAggregator.Service
                 streamStatus.LastCheckTime = DateTime.ParseExact(fields[1], TimestampFormat, CultureInfo.InvariantCulture);
                 streamStatus.IsAlive = bool.Parse(fields[2]);
 
-                if ((DateTime.UtcNow - streamStatus.LastCheckTime).TotalSeconds <= cacheSettings.StreamStatusCacheTimeout)
+                if ((streamStatus.IsAlive == true && (DateTime.UtcNow - streamStatus.LastCheckTime).TotalSeconds > cacheSettings.StreamAliveStatusCacheTimeout) ||
+                    (streamStatus.IsAlive == false && (DateTime.UtcNow - streamStatus.LastCheckTime).TotalSeconds > cacheSettings.StreamDeadStatusCacheTimeout))
                 {
-                    streamStatuses.TryAdd(streamStatus.Url, streamStatus);
+                    continue;
                 }
+
+                streamStatuses.TryAdd(streamStatus.Url, streamStatus);
             }
         }
 

--- a/Service/CacheManager.cs
+++ b/Service/CacheManager.cs
@@ -142,10 +142,24 @@ namespace IptvPlaylistAggregator.Service
             
             if (resolvedUrl is null)
             {
-                return null;
+                return string.Empty;
             }
 
-            return webDownloads.TryGetValue(resolvedUrl);
+            cachedDownload = webDownloads.TryGetValue(resolvedUrl);
+
+            if (!(cachedDownload is null))
+            {
+                return cachedDownload;
+            }
+
+            MediaStreamStatus streamStatus = GetStreamStatus(url);
+
+            if (!(streamStatus is null) && !streamStatus.IsAlive)
+            {
+                return string.Empty;
+            }
+
+            return null;
         }
         
         public void StorePlaylist(string fileContent, Playlist playlist)

--- a/Service/CacheManager.cs
+++ b/Service/CacheManager.cs
@@ -117,8 +117,18 @@ namespace IptvPlaylistAggregator.Service
             MediaStreamStatus streamStatus = streamStatuses.TryGetValue(url);
             
             string resolvedUrl = urlResolutions.TryGetValue(url);
+
+            if (string.IsNullOrWhiteSpace(resolvedUrl))
+            {
+                return new MediaStreamStatus()
+                {
+                    Url = url,
+                    State = StreamState.Dead,
+                    LastCheckTime = DateTime.UtcNow
+                };
+            }
             
-            if (streamStatus is null && !(resolvedUrl is null) && resolvedUrl != url)
+            if (streamStatus is null && resolvedUrl != url)
             {
                 streamStatus = streamStatuses.TryGetValue(resolvedUrl);
             }

--- a/Service/FileDownloader.cs
+++ b/Service/FileDownloader.cs
@@ -70,23 +70,8 @@ namespace IptvPlaylistAggregator.Service
             {
                 urlToUse = resolvedUrl;
             }
-
-            try
-            {
-                content = await SendGetRequestAsync(urlToUse);
-            }
-            catch (HttpRequestException ex)
-            {
-                if (ex.InnerException.Message.Contains("SSL") && uri.Scheme == "http")
-                {
-                    content = await SendGetRequestAsync(url);
-                }
-                else
-                {
-                    throw;
-                }
-            }
-
+            
+            content = await SendGetRequestAsync(urlToUse);
             cache.StoreWebDownload(url, content);
 
             return content;

--- a/Service/ICacheManager.cs
+++ b/Service/ICacheManager.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Security.Cryptography.X509Certificates;
 
 using IptvPlaylistAggregator.Service.Models;
 
@@ -6,14 +7,19 @@ namespace IptvPlaylistAggregator.Service
 {
     public interface ICacheManager
     {
+        void SaveCacheToDisk();
+
         void StoreNormalisedChannelName(string name, string normalisedName);
         string GetNormalisedChannelName(string name);
 
-        void StoreHostnameResolution(string hostname, string ip);
-        string GetHostnameResolution(string hostname);
+        void StoreHost(Host host);
+        Host GetHost(string domain);
 
         void StoreUrlResolution(string url, string ip);
         string GetUrlResolution(string url);
+
+        void StoreSslCertificate(string host, X509Certificate2 certificate);
+        X509Certificate2 GetSslCertificate(string host);
 
         void StoreStreamStatus(MediaStreamStatus status);
         MediaStreamStatus GetStreamStatus(string url);

--- a/Service/IMediaSourceChecker.cs
+++ b/Service/IMediaSourceChecker.cs
@@ -1,5 +1,7 @@
 using System.Threading.Tasks;
 
+using IptvPlaylistAggregator.Service.Models;
+
 namespace IptvPlaylistAggregator.Service
 {
     public interface IMediaSourceChecker

--- a/Service/MediaSourceChecker.cs
+++ b/Service/MediaSourceChecker.cs
@@ -96,7 +96,7 @@ namespace IptvPlaylistAggregator.Service
             
             if (streamState != StreamState.Alive)
             {
-                return StreamState.Dead;
+                return streamState;
             }
 
             string fileContent = await fileDownloader.TryDownloadStringAsync(url);
@@ -114,24 +114,7 @@ namespace IptvPlaylistAggregator.Service
 
         async Task<StreamState> GetStreamStateAsync(string url)
         {
-            string resolvedUrl = dnsResolver.ResolveUrl(url);
-
-            if (string.IsNullOrWhiteSpace(resolvedUrl))
-            {
-                return StreamState.NotFound;
-            }
-
-            Uri uri = new Uri(url);
-            HttpStatusCode statusCode;
-
-            if (uri.Scheme == "http")
-            {
-                statusCode = await GetHttpStatusCode(resolvedUrl);
-            }
-            else
-            {
-                statusCode = await GetHttpStatusCode(url);
-            }
+            HttpStatusCode statusCode = await GetHttpStatusCode(url);
 
             if (statusCode == HttpStatusCode.OK)
             {
@@ -196,7 +179,8 @@ namespace IptvPlaylistAggregator.Service
                     }
                 }
             }
-            
+            catch { }
+
             if (doCacheContent)
             {
                 cache.StoreWebDownload(url, content);

--- a/Service/MediaSourceChecker.cs
+++ b/Service/MediaSourceChecker.cs
@@ -2,6 +2,7 @@ using System;
 using System.Net;
 using System.Threading.Tasks;
 
+using IptvPlaylistAggregator.Configuration;
 using IptvPlaylistAggregator.Logging;
 using IptvPlaylistAggregator.Service.Models;
 
@@ -16,19 +17,22 @@ namespace IptvPlaylistAggregator.Service
         readonly IDnsResolver dnsResolver;
         readonly ICacheManager cache;
         readonly ILogger logger;
+        readonly ApplicationSettings applicationSettings;
 
         public MediaSourceChecker(
             IFileDownloader fileDownloader,
             IPlaylistFileBuilder playlistFileBuilder,
             IDnsResolver dnsResolver,
             ICacheManager cache,
-            ILogger logger)
+            ILogger logger,
+            ApplicationSettings applicationSettings)
         {
             this.fileDownloader = fileDownloader;
             this.playlistFileBuilder = playlistFileBuilder;
             this.dnsResolver = dnsResolver;
             this.cache = cache;
             this.logger = logger;
+            this.applicationSettings = applicationSettings;
         }
 
         public async Task<bool> IsSourcePlayableAsync(string url)
@@ -118,6 +122,7 @@ namespace IptvPlaylistAggregator.Service
             request.Timeout = timeout;
             request.ContinueTimeout = timeout;
             request.ReadWriteTimeout = timeout;
+            request.UserAgent = applicationSettings.UserAgent;
 
             return request;
         }

--- a/Service/MediaSourceChecker.cs
+++ b/Service/MediaSourceChecker.cs
@@ -51,7 +51,7 @@ namespace IptvPlaylistAggregator.Service
 
             if (!(status is null))
             {
-                return status.State == StreamState.Alive;
+                return status.IsAlive;
             }
 
             logger.Verbose(MyOperation.MediaSourceCheck, OperationStatus.Started, new LogInfo(MyLogInfoKey.Url, url));

--- a/Service/Models/Host.cs
+++ b/Service/Models/Host.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace IptvPlaylistAggregator.Service.Models
+{
+    public sealed class Host
+    {
+        public string Domain { get; set; }
+
+        public string Ip { get; set; }
+
+        public DateTime ResolutionTime { get; set; }
+    }
+}

--- a/Service/Models/MediaStreamStatus.cs
+++ b/Service/Models/MediaStreamStatus.cs
@@ -6,6 +6,8 @@ namespace IptvPlaylistAggregator.Service.Models
     {
         public string Url { get; set; }
 
+        public bool IsAlive => State == StreamState.Alive;
+
         public StreamState State { get; set; }
 
         public DateTime LastCheckTime { get; set; }

--- a/Service/Models/MediaStreamStatus.cs
+++ b/Service/Models/MediaStreamStatus.cs
@@ -6,7 +6,7 @@ namespace IptvPlaylistAggregator.Service.Models
     {
         public string Url { get; set; }
 
-        public bool IsAlive { get; set; }
+        public StreamState State { get; set; }
 
         public DateTime LastCheckTime { get; set; }
     }

--- a/Service/Models/StreamState.cs
+++ b/Service/Models/StreamState.cs
@@ -4,6 +4,7 @@ namespace IptvPlaylistAggregator.Service.Models
     {
         Alive,
         Dead,
+        Unauthorised,
         NotFound
     }
 }

--- a/Service/Models/StreamState.cs
+++ b/Service/Models/StreamState.cs
@@ -1,0 +1,9 @@
+namespace IptvPlaylistAggregator.Service.Models
+{
+    public enum StreamState
+    {
+        Alive,
+        Dead,
+        NotFound
+    }
+}

--- a/Service/PlaylistAggregator.cs
+++ b/Service/PlaylistAggregator.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.Collections.Concurrent;
 using System.Linq;
 using System.Threading.Tasks;
 

--- a/Service/PlaylistFetcher.cs
+++ b/Service/PlaylistFetcher.cs
@@ -71,7 +71,14 @@ namespace IptvPlaylistAggregator.Service
         {
             Playlist playlist = null;
 
-            for (int i = 0; i < applicationSettings.DaysToCheck; i++)
+            int daysToCheck = applicationSettings.DaysToCheck;
+
+            if (!provider.UrlFormat.Contains("{0"))
+            {
+                daysToCheck = 1;
+            }
+
+            for (int i = 0; i < daysToCheck; i++)
             {
                 DateTime date = DateTime.Now.AddDays(-i);
 

--- a/Service/PlaylistFetcher.cs
+++ b/Service/PlaylistFetcher.cs
@@ -69,37 +69,7 @@ namespace IptvPlaylistAggregator.Service
 
         public async Task<Playlist> FetchProviderPlaylistAsync(PlaylistProvider provider)
         {
-            Playlist playlist = null;
-
-            int daysToCheck = applicationSettings.DaysToCheck;
-
-            if (!provider.UrlFormat.Contains("{0"))
-            {
-                daysToCheck = 1;
-            }
-
-            for (int i = 0; i < daysToCheck; i++)
-            {
-                DateTime date = DateTime.Now.AddDays(-i);
-
-                playlist = LoadPlaylistFromCache(provider, date);
-                
-                if (playlist is null)
-                {
-                    string playlistFile = await DownloadPlaylistFileAsync(provider, date);
-                    playlist = playlistFileBuilder.TryParseFile(playlistFile);
-
-                    if (!Playlist.IsNullOrEmpty(playlist) && !provider.DontCache)
-                    {
-                        cache.StorePlaylistFile(provider.Id, date, playlistFile);
-                    }
-                }
-                
-                if (!(playlist is null))
-                {
-                    break;
-                }
-            }
+            Playlist playlist = await GetPlaylistAsync(provider);
 
             if (Playlist.IsNullOrEmpty(playlist))
             {
@@ -124,6 +94,60 @@ namespace IptvPlaylistAggregator.Service
                 OperationStatus.Success,
                 new LogInfo(MyLogInfoKey.Provider, provider.Name));
                 
+            return playlist;
+        }
+
+        async Task<Playlist> GetPlaylistAsync(PlaylistProvider provider)
+        {
+            Playlist playlist = await GetPlaylistForTodayAsync(provider);
+            
+            if (Playlist.IsNullOrEmpty(playlist))
+            {
+                playlist = GetPlaylistForPastDays(provider);
+            }
+
+            return playlist;
+        }
+
+        async Task<Playlist> GetPlaylistForTodayAsync(PlaylistProvider provider)
+        {
+            string playlistFile = await DownloadPlaylistFileAsync(provider, DateTime.UtcNow);
+            Playlist playlist = LoadPlaylistFromCache(provider, DateTime.UtcNow);
+
+            if (playlist is null)
+            {
+                playlist = playlistFileBuilder.TryParseFile(playlistFile);
+            }
+
+            if (!Playlist.IsNullOrEmpty(playlist) && !provider.DontCache)
+            {
+                cache.StorePlaylistFile(provider.Id, DateTime.UtcNow, playlistFile);
+            }
+
+            return playlist;
+        }
+
+        Playlist GetPlaylistForPastDays(PlaylistProvider provider)
+        {
+            if (!provider.UrlFormat.Contains("{0"))
+            {
+                return null;
+            }
+
+            Playlist playlist = null;
+
+            for (int i = 1; i < applicationSettings.DaysToCheck; i++)
+            {
+                DateTime date = DateTime.UtcNow.AddDays(-i);
+
+                playlist = LoadPlaylistFromCache(provider, date);
+
+                if (!(playlist is null))
+                {
+                    break;
+                }
+            }
+
             return playlist;
         }
 

--- a/appsettings.json
+++ b/appsettings.json
@@ -16,6 +16,7 @@
         "hostCacheTimeout": "43200",
         "streamAliveStatusCacheTimeout": "2000",
         "streamDeadStatusCacheTimeout": "3600",
+        "streamUnauthorisedStatusCacheTimeout": "86400",
         "streamNotFoundStatusCacheTimeout": "86400"
     },
     "dataStoreSettings": {

--- a/appsettings.json
+++ b/appsettings.json
@@ -17,7 +17,7 @@
         "streamAliveStatusCacheTimeout": "2000",
         "streamDeadStatusCacheTimeout": "3600",
         "streamUnauthorisedStatusCacheTimeout": "86400",
-        "streamNotFoundStatusCacheTimeout": "86400"
+        "streamNotFoundStatusCacheTimeout": "129600"
     },
     "dataStoreSettings": {
         "channelStorePath": "Data/channels.xml",

--- a/appsettings.json
+++ b/appsettings.json
@@ -9,7 +9,7 @@
         "daysToCheck": "7",
         "canIncludeUnmatchedChannels": "true",
         "areTvGuideTagsEnabled": "true",
-        "userAgent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.117 Safari/537.36"
+        "userAgent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.106 Safari/537.36"
     },
     "cacheSettings": {
         "cacheDirectoryPath": "Cache",

--- a/appsettings.json
+++ b/appsettings.json
@@ -12,7 +12,9 @@
         "userAgent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.117 Safari/537.36"
     },
     "cacheSettings": {
-        "cacheDirectoryPath": "Cache"
+        "cacheDirectoryPath": "Cache",
+        "hostCacheTimeout": "43200",
+        "streamStatusCacheTimeout": "7200"
     },
     "dataStoreSettings": {
         "channelStorePath": "Data/channels.xml",

--- a/appsettings.json
+++ b/appsettings.json
@@ -15,7 +15,8 @@
         "cacheDirectoryPath": "Cache",
         "hostCacheTimeout": "43200",
         "streamAliveStatusCacheTimeout": "2000",
-        "streamDeadStatusCacheTimeout": "7200"
+        "streamDeadStatusCacheTimeout": "3600",
+        "streamNotFoundStatusCacheTimeout": "86400"
     },
     "dataStoreSettings": {
         "channelStorePath": "Data/channels.xml",

--- a/appsettings.json
+++ b/appsettings.json
@@ -6,7 +6,7 @@
     },
     "applicationSettings": {
         "outputPlaylistPath": "result.m3u",
-        "daysToCheck": "5",
+        "daysToCheck": "7",
         "canIncludeUnmatchedChannels": "true",
         "areTvGuideTagsEnabled": "true",
         "userAgent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.117 Safari/537.36"
@@ -14,7 +14,7 @@
     "cacheSettings": {
         "cacheDirectoryPath": "Cache",
         "hostCacheTimeout": "43200",
-        "streamStatusCacheTimeout": "7200"
+        "streamStatusCacheTimeout": "2000"
     },
     "dataStoreSettings": {
         "channelStorePath": "Data/channels.xml",

--- a/appsettings.json
+++ b/appsettings.json
@@ -14,7 +14,8 @@
     "cacheSettings": {
         "cacheDirectoryPath": "Cache",
         "hostCacheTimeout": "43200",
-        "streamStatusCacheTimeout": "2000"
+        "streamAliveStatusCacheTimeout": "2000",
+        "streamDeadStatusCacheTimeout": "7200"
     },
     "dataStoreSettings": {
         "channelStorePath": "Data/channels.xml",


### PR DESCRIPTION
 - Parallelised (again) the channel matching
 - Improved hostname resoltion
 - Improved media status checking
 - Improved and extended caching
 - Removed some dead providers
 - Added some new providers
 - Added some more channels and channel aliases
 - Increased the number of days to check to 7 (was 5)
 - Skip multi-day checking for providers with fixed URLs
 - Updated the UserAgent
 - Improved fatal exception logging for AggregateExceptions
 - Only download playlists for the current day