### PR TITLE
Upgrade to the framework and the dependencies

### DIFF
--- a/IptvPlaylistAggregator.csproj
+++ b/IptvPlaylistAggregator.csproj
@@ -22,11 +22,11 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="NuciDAL" Version="1.1.1" />
-    <PackageReference Include="NuciExtensions" Version="1.4.1.1" />
-    <PackageReference Include="NuciLog" Version="1.1.0" />
-    <PackageReference Include="NuciLog.Core" Version="2.2.5" />
+    <PackageReference Include="NuciExtensions" Version="1.4.1.2" />
+    <PackageReference Include="NuciLog" Version="1.1.0.1" />
+    <PackageReference Include="NuciLog.Core" Version="2.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/IptvPlaylistAggregator.csproj
+++ b/IptvPlaylistAggregator.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <RootNamespace>IptvPlaylistAggregator</RootNamespace>
   </PropertyGroup>
 
@@ -17,11 +17,11 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
     <PackageReference Include="NuciDAL" Version="1.1.1" />
     <PackageReference Include="NuciExtensions" Version="1.4.1.1" />

--- a/package.sh
+++ b/package.sh
@@ -36,17 +36,7 @@ function dotnet-pub {
     dotnet publish -c Release -r "$ARCH" -o "$OUTPUT_DIR" --self-contained=true /p:TrimUnusedDependencies=true /p:LinkDuringPublish=true
 }
 
-function prepare {
-    echo "Adding the temporary NuGet packages"
-    dotnet add package Microsoft.Packaging.Tools.Trimming --version 1.1.0-preview1-26619-01
-    #dotnet add package ILLink.Tasks --version 0.1.5-preview-1841731 --source https://dotnet.myget.org/F/dotnet-core/api/v3/index.json
-}
-
 function cleanup {
-    echo "Removing the temporary NuGet packages"
-    dotnet remove package Microsoft.Packaging.Tools.Trimming
-    #dotnet remove package ILLink.Task
-
     echo "Cleaning build output"
     rm -rf "$PUBLISH_DIR"
 }
@@ -56,12 +46,10 @@ function build-release {
     package $1
 }
 
-prepare
-
 build-release linux-arm
 build-release linux-arm64
 build-release linux-x64
-build-release osx-x64
 build-release win-x64
+build-release osx-x64
 
 cleanup


### PR DESCRIPTION
 - Upgraded the framework from `netcore3.1` to `net5.0`
 - Updated `Newtonsoft.Json` from `12.0.2` to `13.0.1`
 - Updated `NuciExtensions` from `1.4.1.1` to `.1.4.1.2`
 - Updated `NuciLog` from `1.1.0` to `1.1.0.1`
 - Updated `NuciLog.Core` from `2.2.5` to `2.3.1`
 - Removed the trimming NuGet package from the packaging script